### PR TITLE
fix: Fixed swift versioning that caused infinite loop

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.2
 
 //
 //  Package.Swift

--- a/Sources/DataBytes/Data+Extensions.swift
+++ b/Sources/DataBytes/Data+Extensions.swift
@@ -28,7 +28,6 @@ internal extension Data {
     struct ByteError: Swift.Error {}
     
     func withUnsafeBytes<ResultType, ContentType>(_ completion: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
-        #if swift(>=5.0)
         return try withUnsafeBytes { 
             if let baseAddress = $0.baseAddress, $0.count > 0 {
                 return try completion(baseAddress.assumingMemoryBound(to: ContentType.self))
@@ -36,13 +35,9 @@ internal extension Data {
                 throw ByteError()
             }
         }
-        #else
-        return try withUnsafeBytes(completion)
-        #endif
     }
     
     mutating func withUnsafeMutableBytes<ResultType, ContentType>(_ completion: (UnsafeMutablePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
-        #if swift(>=5.0)
         return try withUnsafeMutableBytes {
             if let baseAddress = $0.baseAddress, $0.count > 0 {
                 return try completion(baseAddress.assumingMemoryBound(to: ContentType.self))
@@ -50,8 +45,5 @@ internal extension Data {
                 throw ByteError()
             }
         }
-        #else
-        return try withUnsafeMutableBytes(completion)
-        #endif
     }
 }


### PR DESCRIPTION
- There were some unnecessary version checks in the code--and the "else" handler was causing an infinite loop.
- Updated the package to use Swift 5.2 for our purposes