### PR TITLE
fix: Removed TCPTransport option that was causing performance issues on iOS 12

### DIFF
--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -120,14 +120,18 @@ open class WebSocket: WebSocketClient, EngineDelegate {
         self.engine = engine
     }
     
-    public convenience init(request: URLRequest, certPinner: CertificatePinning? = FoundationSecurity(), compressionHandler: CompressionHandler? = nil, useCustomEngine: Bool = true) {
-        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *), !useCustomEngine {
+    public convenience init(request: URLRequest) {
+        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
             self.init(request: request, engine: NativeEngine())
-        } else if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
-            self.init(request: request, engine: WSEngine(transport: TCPTransport(), certPinner: certPinner, compressionHandler: compressionHandler))
         } else {
-            self.init(request: request, engine: WSEngine(transport: FoundationTransport(), certPinner: certPinner, compressionHandler: compressionHandler))
+            self.init(request: request, engine: WSEngine(transport: FoundationTransport(), certPinner: FoundationSecurity(), compressionHandler: nil))
         }
+    }
+    
+    public convenience init(request: URLRequest,
+                            certPinner: CertificatePinning? = FoundationSecurity(),
+                            compressionHandler: CompressionHandler? = nil) {
+        self.init(request: request, engine: WSEngine(transport: FoundationTransport(), certPinner: certPinner, compressionHandler: compressionHandler))
     }
     
     public func connect() {


### PR DESCRIPTION
- `TCPTransport()` was doing a blocking readLoop() that was causing high CPU usage for iOS 12+. There isn't much documentation on how to address that, so I just removed it as an option completely. If you're on iOS 13+, it will use Apple's native `URLSessionWebSocketTask`, else it'll use the (deprecated) Foundation transport. 
-  I thought it was kinda weird that you could specify a cert pinner/compression handler, and if you happened to set `useCustomEngine` to false, those parameters would be completely ignored. So I separated them into two initializers and removed the `useCustomEngine` option is removed.