### PR TITLE
fix: Removed native engine usage due to socket connection errors

### DIFF
--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -120,14 +120,6 @@ open class WebSocket: WebSocketClient, EngineDelegate {
         self.engine = engine
     }
     
-    public convenience init(request: URLRequest) {
-        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-            self.init(request: request, engine: NativeEngine())
-        } else {
-            self.init(request: request, engine: WSEngine(transport: FoundationTransport(), certPinner: FoundationSecurity(), compressionHandler: nil))
-        }
-    }
-    
     public convenience init(request: URLRequest,
                             certPinner: CertificatePinning? = FoundationSecurity(),
                             compressionHandler: CompressionHandler? = nil) {


### PR DESCRIPTION
- Removed native engine usage until further notice. It currently doesn't seem to obey the expected contract--attempting to `write` after a `connected` event leads to an explosion of errors from my testing.