### PR TITLE
fix: Prevent infinite read-loop on error 

### DIFF
--- a/Sources/Engine/NativeEngine.swift
+++ b/Sources/Engine/NativeEngine.swift
@@ -69,11 +69,13 @@ public class NativeEngine: NSObject, Engine, URLSessionDataDelegate, URLSessionW
                 @unknown default:
                     break
                 }
-                break
+                
+                self?.doRead()
+                
             case .failure(let error):
                 self?.broadcast(event: .error(error))
             }
-            self?.doRead()
+            
         }
     }
 

--- a/Sources/Engine/NativeEngine.swift
+++ b/Sources/Engine/NativeEngine.swift
@@ -11,15 +11,21 @@ import Foundation
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public class NativeEngine: NSObject, Engine, URLSessionDataDelegate, URLSessionWebSocketDelegate {
     private var task: URLSessionWebSocketTask?
+    private var session: URLSession?
     weak var delegate: EngineDelegate?
+    
+    deinit {
+        stop(closeCode: CloseCode.normal.rawValue)
+    }
 
     public func register(delegate: EngineDelegate) {
         self.delegate = delegate
     }
 
     public func start(request: URLRequest) {
-        let session = URLSession(configuration: URLSessionConfiguration.default, delegate: self, delegateQueue: nil)
-        task = session.webSocketTask(with: request)
+        let sessionDelegate = WebSocketDelegateProxy(handler: self)
+        session = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
+        task = session?.webSocketTask(with: request)
         doRead()
         task?.resume()
     }
@@ -27,6 +33,7 @@ public class NativeEngine: NSObject, Engine, URLSessionDataDelegate, URLSessionW
     public func stop(closeCode: UInt16) {
         let closeCode = URLSessionWebSocketTask.CloseCode(rawValue: Int(closeCode)) ?? .normalClosure
         task?.cancel(with: closeCode, reason: nil)
+        session?.invalidateAndCancel()
     }
 
     public func forceStop() {
@@ -75,7 +82,6 @@ public class NativeEngine: NSObject, Engine, URLSessionDataDelegate, URLSessionW
             case .failure(let error):
                 self?.broadcast(event: .error(error))
             }
-            
         }
     }
 
@@ -95,4 +101,33 @@ public class NativeEngine: NSObject, Engine, URLSessionDataDelegate, URLSessionW
         }
         broadcast(event: .disconnected(r, UInt16(closeCode.rawValue)))
     }
+}
+
+/// URLSession holds onto its delegate with a strong reference, so this class
+/// acts as an intermediate handler. The URLSession will hold a strong reference to it,
+/// and this will hold a weak reference to the true delegate, allowing us to gracefully
+/// deinitialize within NativeEngine.
+///
+///     NativeEngine ------> URLSession ------> DelegateProxy
+///         ^        strong             strong        |
+///         |                                         |
+///          ----------------- weak ------------------
+///
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+class WebSocketDelegateProxy: NSObject, URLSessionWebSocketDelegate {
+    
+    weak var delegate: URLSessionWebSocketDelegate?
+    
+    init(handler: URLSessionWebSocketDelegate?) {
+        self.delegate = handler
+    }
+    
+    public func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
+        delegate?.urlSession?(session, webSocketTask: webSocketTask, didOpenWithProtocol: `protocol`)
+    }
+    
+    public func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        delegate?.urlSession?(session, webSocketTask: webSocketTask, didCloseWith: closeCode, reason: reason)
+    }
+    
 }

--- a/Sources/Transport/FoundationTransport.swift
+++ b/Sources/Transport/FoundationTransport.swift
@@ -47,6 +47,11 @@ public class FoundationTransport: NSObject, Transport, StreamDelegate {
         onConnect = streamConfiguration
     }
     
+    deinit {
+        inputStream?.delegate = nil
+        outputStream?.delegate = nil
+    }
+    
      public func connect(url: URL, timeout: Double = 10, certificatePinning: CertificatePinning? = nil) {
         guard let parts = url.getParts() else {
             delegate?.connectionChanged(state: .failed(FoundationTransportError.invalidRequest))

--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -141,7 +141,10 @@ public class TCPTransport: Transport {
             if let data = data {
                 s.delegate?.connectionChanged(state: .receive(data))
             }
-            s.readLoop()
+            
+            if error == nil {
+                s.readLoop()
+            }
         })
     }
 }


### PR DESCRIPTION
- Fixes an infinite loop when an error occurs in NativeEngine. This requires that you reconnect to receive updates after an error.
- Fixes an infinite loop when an error occurs in TCPTransport
- Fixes a memory leak in NativeEngine
- Fixes a crash in FoundationTransport, thanks to: https://github.com/daltoniam/Starscream/pull/777